### PR TITLE
accept any param

### DIFF
--- a/dist/fm-mock.d.ts
+++ b/dist/fm-mock.d.ts
@@ -42,7 +42,7 @@ declare const mockScript: (scriptName: string, functionToCall: (param: string) =
  * @param options.logParams - Specifies whether to log the parameters that will be received by FM.
  */
 declare const mockGoferScript: (scriptName: string, options?: GoferOptions | undefined) => void;
-declare type ResultFunction = (parameter: string) => string | number | Record<string, unknown> | any[] | void;
+declare type ResultFunction = (parameter: any) => string | number | Record<string, unknown> | any[] | void;
 declare type AsyncResultFunction = (...args: Parameters<ResultFunction>) => Promise<ReturnType<ResultFunction>>;
 declare type ScriptOption = 0 | 1 | 2 | 3 | 4 | 5 | '0' | '1' | '2' | '3' | '4' | '5';
 /**

--- a/src/fm-mock.ts
+++ b/src/fm-mock.ts
@@ -148,7 +148,8 @@ const mockGoferScript = (scriptName: string, options?: GoferOptions) => {
 };
 
 type ResultFunction = (
-  parameter: string
+  // parameter is `any` to match FMGofer.PerformScript's `any` parameter type.
+  parameter: any
 ) => string | number | Record<string, unknown> | any[] | void;
 
 type AsyncResultFunction = (


### PR DESCRIPTION
accept any param because FMGofer will wrap the parameter in an object and stringify that. That allows objects and arrays to be passed as-is to FM